### PR TITLE
chore: use py310 for Ubuntu 22.04 and set 2024.1 constraints

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.18.0
-envlist = py38,pep8
+envlist = py310,pep8
 # Automatic envs (pyXX) will only use the python version appropriate to that
 # env and ignore basepython inherited from [testenv] if we set
 # ignore_basepython_conflict.
@@ -19,7 +19,7 @@ setenv =
     VIRTUAL_ENV={envdir}
     OS_TEST_PATH=cyborg/tests/unit
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1}
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
 


### PR DESCRIPTION
Update the default Python version from py38 to py310 to match the default Python on Ubuntu 22.04.

Also switch the constraints file from 'master' to '2024.1' to ensure compatibility with the stable/2024.1 branch.

To test locally:
    tox
    tox -e py310
    tox -e pep8