### PR TITLE
refactor: replace session helpers with decorators

### DIFF
--- a/cyborg/tests/base.py
+++ b/cyborg/tests/base.py
@@ -18,7 +18,6 @@ from unittest import mock
 
 from oslo_config import cfg
 from oslo_config import fixture as config_fixture
-from oslo_context import context
 from oslo_db import options
 from oslo_log import log
 from oslo_utils import excutils
@@ -29,6 +28,7 @@ import eventlet
 import testtools
 
 from cyborg.common import config as cyborg_config
+from cyborg import context as cyborg_context
 from cyborg.tests import post_mortem_debug
 from cyborg.tests.unit import policy_fixture
 
@@ -46,7 +46,7 @@ class TestCase(base.BaseTestCase):
 
     def setUp(self):
         super(TestCase, self).setUp()
-        self.context = context.get_admin_context()
+        self.context = cyborg_context.get_admin_context()
         self._set_config()
         self.policy = self.useFixture(policy_fixture.PolicyFixture())
 
@@ -100,7 +100,7 @@ class DietTestCase(base.BaseTestCase):
 
     def setUp(self):
         super(DietTestCase, self).setUp()
-        self.context = context.get_admin_context()
+        self.context = cyborg_context.get_admin_context()
 
         options.set_defaults(cfg.CONF, connection='sqlite://')
 

--- a/cyborg/tests/unit/agent/test_rpcapi.py
+++ b/cyborg/tests/unit/agent/test_rpcapi.py
@@ -17,9 +17,9 @@ import oslo_messaging as messaging
 from cyborg.agent.rpcapi import AgentAPI
 from cyborg.common import constants
 from cyborg.common import rpc
+from cyborg import context as cyborg_context
 from cyborg.objects import base as objects_base
 from cyborg.tests import base
-from oslo_context import context as oslo_context
 from unittest import mock
 
 
@@ -40,8 +40,8 @@ class TestRPCAPI(base.TestCase):
                                      serializer=self.serializer)
 
     def _test_rpc_call(self, method):
-        ctxt = oslo_context.RequestContext(user_id='fake_user',
-                                           project_id='fake_project')
+        ctxt = cyborg_context.RequestContext(user_id='fake_user',
+                                             project_id='fake_project')
         expect_val = True
         with mock.patch.object(self.agent_rpcapi,
                                'fpga_program') as mock_program:

--- a/cyborg/tests/unit/api/base.py
+++ b/cyborg/tests/unit/api/base.py
@@ -16,10 +16,10 @@
 """Base classes for API tests."""
 
 from oslo_config import cfg
-from oslo_context import context
 import pecan
 import pecan.testing
 
+from cyborg import context as cyborg_context
 from cyborg.tests.unit.db import base
 
 cfg.CONF.import_group('keystone_authtoken', 'keystonemiddleware.auth_token')
@@ -114,7 +114,7 @@ class BaseApiTest(base.DbTestCase):
                                   status=status, method="post")
 
     def gen_context(self, value, **kwargs):
-        ct = context.RequestContext.from_dict(value, **kwargs)
+        ct = cyborg_context.RequestContext.from_dict(value, **kwargs)
         return ct
 
     def gen_headers(self, context, **kw):

--- a/cyborg/tests/unit/db/base.py
+++ b/cyborg/tests/unit/db/base.py
@@ -17,9 +17,9 @@
 
 import fixtures
 from oslo_config import cfg
-from oslo_db.sqlalchemy import enginefacade
 
 from cyborg.db import api as dbapi
+from cyborg.db.sqlalchemy import api as sqlalchemy_api
 from cyborg.db.sqlalchemy import migration
 from cyborg.db.sqlalchemy import models
 from cyborg.tests import base
@@ -65,7 +65,11 @@ class DbTestCase(base.TestCase):
 
         global _DB_CACHE
         if not _DB_CACHE:
-            engine = enginefacade.get_legacy_facade().get_engine()
+            engine = (
+                sqlalchemy_api.main_context_manager
+                .get_legacy_facade()
+                .get_engine()
+            )
             _DB_CACHE = Database(engine, migration,
                                  sql_connection=CONF.database.connection)
         self.useFixture(_DB_CACHE)

--- a/cyborg/tests/unit/objects/test_objects.py
+++ b/cyborg/tests/unit/objects/test_objects.py
@@ -16,8 +16,8 @@ import datetime
 
 from oslo_log import log
 
-from oslo_context import context
 
+from cyborg import context as cyborg_context
 from cyborg.objects import base
 from cyborg.objects import fields
 from cyborg import tests as test
@@ -192,7 +192,8 @@ class _BaseTestCase(test.base.TestCase):
         super(_BaseTestCase, self).setUp()
         self.user_id = 'fake-user'
         self.project_id = 'fake-project'
-        self.context = context.RequestContext(self.user_id, self.project_id)
+        self.context = cyborg_context.RequestContext(self.user_id,
+                                                     self.project_id)
 
         base.CyborgObjectRegistry.register(MyObj)
         base.CyborgObjectRegistry.register(MyOwnedObject)


### PR DESCRIPTION
Cyborg’s DB layer was manually opening sessions via thread-local helpers
(_CONTEXT, _session_for_read/_write) and doing ad-hoc session management
(add/flush/commit). Under eventlet this led to blocking calls from the
mainloop and, over time, SQLAlchemy QueuePool exhaustion (timeouts) as
reported in [LP#2061130](https://bugs.launchpad.net/openstack-cyborg/+bug/2061130).

Fix #5, #6

--
This change simplifies database session management and provides better
control over read/write operations through a decorator-based approach.

- Replace _session_for_read() and _session_for_write() context managers
  with @main_context_manager.reader and @main_context_manager.writer
  decorators
- Update all database API methods to use context.session directly
- Remove manual session handling (add/flush/commit) in favor of
  centralized transaction management via enginefacade
- Improve consistency and prevent connection pool exhaustion under
  eventlet